### PR TITLE
Added support for replacing values inside application settings sections

### DIFF
--- a/task/index.ts
+++ b/task/index.ts
@@ -110,14 +110,19 @@ var replaceTokensInFile = function (filePath: string, encoding: string, writeBOM
                 loopVar = e.value.indexOf(tokenPrefix) > -1;
             }
 
-            let masterRegEx = new RegExp('(?:"' + name + '").*?(?:value="|connectionString=")(.*?)"', 'gm');
-            content = content.replace(masterRegEx, (match, caption) => {
-                tl.debug('match: ' + match + ' with caption: ' + caption + ' will be replace with: ' + e.value);
+            let masterRegExps = 
+                [new RegExp('(?:"' + name + '").*?(?:value="|connectionString=")(.*?)"', 'gm'),
+                 new RegExp('(?:name="' + name + '").*?>\\s*<value>(.*?)<\/value>', 'gm')];
 
-                let val = match.replace(caption == '' ? '""' : caption, caption == '' ? '"'+ e.value +'"' :  e.value);
-                tl.debug('variable replaced: ' + val);
-                return val;
-            });
+            masterRegExps.forEach(masterRegEx => {
+                content = content.replace(masterRegEx, (match, caption) => {
+                    tl.debug('match: ' + match + ' with caption: ' + caption + ' will be replace with: ' + e.value);
+                    
+                    let val = match.replace(caption == '' ? '""' : caption, caption == '' ? '"'+ e.value +'"' :  e.value);
+                    tl.debug('variable replaced: ' + val);
+                    return val;
+                });
+            })
         }
     });
 


### PR DESCRIPTION
Added support for configuration sections which inherits from `System.Configuration.ApplicationSettingsBase` and looks like:
```
<Foo.Bar.Configuration.FooBarSettings>
    <setting name="ValidateSomething" serializeAs="String">
        <value>False</value>
    </setting>
    <setting name="TimeOffset" serializeAs="String">
        <value>00:15:00</value>
    </setting>
</Foo.Bar.Configuration.FooBarSettings>
```

After my change is possible to replace values of such variables.

@digitalmedia34  please write what version should I set? 1.3.4 and treat it as a bug or 1.4.0 and treat it as new feature?