### PR TITLE
Added support for replacing multiline values inside application setting sections

### DIFF
--- a/task/index.ts
+++ b/task/index.ts
@@ -112,7 +112,7 @@ var replaceTokensInFile = function (filePath: string, encoding: string, writeBOM
 
             let masterRegExps = 
                 [new RegExp('(?:"' + name + '")[^>]*?(?:value="|connectionString=")(.*?)"','gm'),
-                 new RegExp('(?:name="' + name + '").*?>\\s*<value>(.*?)<\/value>', 'gm')];
+                 new RegExp('(?:name="' + name + '").*?>\\s*<value>([\\S\\s]*?)<\/value>', 'gm')];
 
             masterRegExps.forEach(masterRegEx => {
                 content = content.replace(masterRegEx, (match, caption) => {

--- a/task/task.json
+++ b/task/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 4,
-        "Patch": 3
+        "Patch": 4
     },
     "minimumAgentVersion": "2.105.0",
     "groups": [


### PR DESCRIPTION
Added support for replacing **multiline** values inside configuration sections which inherits from   `System.Configuration.ApplicationSettingsBase` and looks like:
```
<Foo.Bar.Configuration.FooBarSettings>
    <setting name="ColumnColors" serializeAs="Xml">
        <value>
            <string>Column1=White;White;White;White</string>
            <string>Column2=White;White;White;White</string>
        </value>
    </setting>
</Foo.Bar.Configuration.FooBarSettings>
```
